### PR TITLE
Reduce compilation size

### DIFF
--- a/bin/compile-css.js
+++ b/bin/compile-css.js
@@ -27,6 +27,7 @@ const unifiedAssetMap = (done) => {
 
 const sassOptions = {
   includePaths: cssConfig.includePaths,
+  outputStyle: 'compressed',
 
   functions: {
     'asset-url($file)': (file, done) => {

--- a/bin/compile-css.js
+++ b/bin/compile-css.js
@@ -4,7 +4,6 @@
 const gulp = require('gulp')
 const prefix = require('gulp-autoprefixer')
 const sass = require('gulp-sass')
-const sourcemaps = require('gulp-sourcemaps')
 const rename = require('gulp-rename')
 const hasher = require('gulp-hasher')
 const SassString = require('node-sass').types.String
@@ -82,12 +81,10 @@ const calculateRenameMap = (entryPoints, hashes) => {
 
 gulp.task('compile-css', () => gulp
   .src(Object.keys(cssConfig.entryPoints).map((artifact) => cssConfig.entryPoints[artifact]))
-  .pipe(sourcemaps.init())
   .pipe(sass(sassOptions).on('error', sass.logError))
   .pipe(prefix(cssConfig.prefixes))
   .pipe(hasher())
   .pipe(rename((p) => renameFilesAccordingToMap(calculateRenameMap(cssConfig.entryPoints, hasher.hashes), p)))
-  .pipe(sourcemaps.write())
   .pipe(gulp.dest(cssConfig.target.directory))
   .on('end', () => assetMapLib.writeAssetMap(assetMapLib.addPathToAssetMap('stylesheets', calculateAssetMap(cssConfig.entryPoints, hasher.hashes)), 'stylesheets'))
 )

--- a/bin/compile-js.js
+++ b/bin/compile-js.js
@@ -25,6 +25,9 @@ const compiler = webpack({
     path: path.join('.', jsConfig.target.directory),
     filename: '[name]-[hash].js'
   },
+  plugins: [
+    new webpack.optimize.UglifyJsPlugin()
+  ],
   resolve: {
     root: jsConfig.includePaths.map((p) => path.resolve(p)),
     alias: jsConfig.alias

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "gulp-hasher": "^0.1.0",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.2.0",
-    "gulp-sourcemaps": "^1.6.0",
     "gulp-util": "^3.0.7",
     "webpack": "^1.12.15"
   }


### PR DESCRIPTION
- Remove sourcemaps from CSS
- Use the `compress` output format for SCSS
- Use UglifyJS
