### PR TITLE
Compile before watching and preparing release 0.4.1

### DIFF
--- a/bin/compile-css.js
+++ b/bin/compile-css.js
@@ -101,7 +101,7 @@ gulp.task('watch-css', () => {
 })
 
 if (process.argv[2] && process.argv[2] === '--watch') {
-  gulp.start('watch-css')
+  gulp.start([ 'compile-css', 'watch-css' ])
 } else {
   gulp.start('compile-css')
 }

--- a/bin/compile-fonts.js
+++ b/bin/compile-fonts.js
@@ -31,7 +31,7 @@ gulp.task('watch-fonts', () => {
 })
 
 if (process.argv[2] && process.argv[2] === '--watch') {
-  gulp.start('watch-fonts')
+  gulp.start([ 'compile-fonts', 'watch-fonts' ])
 } else {
   gulp.start('compile-fonts')
 }

--- a/bin/compile-images.js
+++ b/bin/compile-images.js
@@ -31,7 +31,7 @@ gulp.task('watch-images', () => {
 })
 
 if (process.argv[2] && process.argv[2] === '--watch') {
-  gulp.start('watch-images')
+  gulp.start([ 'compile-images', 'watch-images' ])
 } else {
   gulp.start('compile-images')
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fejo-asset-pipeline",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "An asset pipeline for ES2015 and SCSS",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
* Run the `compile` task before the `watch` task for CSS, images and fonts (JS already does that)
* Release 0.4.1